### PR TITLE
Fix exporting of scenarios in YAML format

### DIFF
--- a/stubo/model/exporter.py
+++ b/stubo/model/exporter.py
@@ -55,7 +55,7 @@ class Exporter(object):
                       stubs=[])
         export_payload = dict(recording=header)
         scenario_db = Scenario()
-        stubs = list(scenario_db.get_pre_stubs(scenario))
+        stubs = list(scenario_db.get_stubs(scenario))
         if len(stubs) > 0:
             for i in range(len(stubs)):
                 entry = stubs[i]

--- a/stubo/utils/__init__.py
+++ b/stubo/utils/__init__.py
@@ -232,7 +232,7 @@ def make_temp_dir(dirname=None):
 def get_export_links(request, scenario_name_key, files):
     # the export uses the local file system so the link needs to refer to the
     # server that has performed the export.  
-    local_server = 'http://{0}:{1}'.format(request.track.server,
+    local_server = 'http://{0}:{1}'.format(request.track.host,
                                            request.track.port or 8001)
     return [(x[0], local_server + request.static_url(os.path.join(
         'exports', scenario_name_key.replace(':', '_'), x[0]))) for x in files]


### PR DESCRIPTION
Exporting of stubs has been broken with the migration to ReactJS and
the new UI (Mirage rebrading). There was implemented int the
ea5e1fb6028c312768cc2bd8f7233fd4c08c637e commit. This commit switches
from using pre_scenario_stub collection to using scenario_stub which
contains stubs after they have been converted and matchers applied.